### PR TITLE
Sync labels

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -62,6 +62,7 @@ jobs:
           # Filenames of the shared configurations to apply to the repository in addition to the local configuration.
           # https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/sync-labels
           - universal.yml
+          - tooling.yml
 
     steps:
       - name: Download


### PR DESCRIPTION
On every push that changes relevant files, and periodically, use [github-label-sync](https://github.com/Financial-Times/github-label-sync) to configure the repository's issue/PR labels according to the universal, shared, and local label configuration files.