### PR TITLE
Remove superfluous container authorization from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,6 @@ jobs:
 
     container:
       image: ghcr.io/arduino/crossbuild:0.2.1
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.AVRDUDE_CI_PAT }}
     
     steps:
     # the tag must be formatted this way <AVRDUDE_TAG>-arduino.<ARDUINO_VERSION>, e.g tag -> 7.0-arduino.1


### PR DESCRIPTION
The "release" [GitHub Actions workflow](https://docs.github.com/actions/using-workflows/about-workflows) cross-compiles [AVRDUDE](https://github.com/avrdudes/avrdude) in a container.

At the time the workflow was written, [the arduino/crossbuild container](https://github.com/arduino/crossbuild/pkgs/container/crossbuild) was [configured as private](https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility#visibility-and-access-permissions-for-container-images), meaning it was necessary to configure the workflow to use a personal access token from an account with the necessary permissions in [the `arduino` GitHub organization](https://github.com/arduino) in order for it to be able to run.

Since that time, the container has been made public. The [configuration of the workflow to provide credentials for container access](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontainercredentials) is now superfluous, making the workflow more difficult for use by contributors and reuse by the community, and increasing the project's maintenance burden and potential attack surface through the presence of an unnecessary token.

This unnecessary workflow configuration is hereby removed, taking advantage of the new possibility of pulling the container anonymously.

---

Demo run of the workflow with the proposed changes in my fork: https://github.com/per1234/avrdude-packing/actions/runs/2578349924